### PR TITLE
Handle Buffer inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mergekit",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Uniquely flexible and light-weight utility for cloning and deep (recursive) merging of JavaScript objects. Supports descriptor values, accessor functions, and custom prototypes. Provides advanced options for customizing the clone/merge process.",
   "author": "Josue Monteiro",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,6 +296,10 @@ export function mergekit(
         else if (mergeVal instanceof Date) {
           mergeVal = new Date(mergeVal);
         }
+        // Buffers
+        else if (Buffer.isBuffer(mergeVal)) {
+          mergeVal = mergeVal.toString('utf-8');
+        }
         // Objects
         else if (
           isObject(mergeVal) &&

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1042,3 +1042,35 @@ describe('onlyObjectWithKeyValues', () => {
     ]);
   });
 });
+
+describe('Mergekit Buffers', () => {
+  test('merges buffer values correctly', () => {
+    const buffer1 = Buffer.from('Hello');
+    const buffer2 = Buffer.from('World');
+
+    const mergedObj = mergekit([{ a: buffer1 }, { b: buffer2 }]);
+
+    expect(mergedObj.a).toBe('Hello');
+    expect(mergedObj.b).toBe('World');
+  });
+
+  test('handles buffer values in an object', () => {
+    const buffer = Buffer.from('Test Buffer');
+    const obj = { a: buffer };
+
+    const mergedObj = mergekit(obj);
+
+    expect(mergedObj.a).toBe('Test Buffer');
+  });
+
+  test('merges buffer values with other types', () => {
+    const buffer = Buffer.from('Buffer');
+    const obj1 = { a: buffer };
+    const obj2 = { b: ' and String' };
+
+    const mergedObj = mergekit([obj1, obj2]);
+
+    expect(mergedObj.a).toBe('Buffer');
+    expect(mergedObj.b).toBe(' and String');
+  });
+});


### PR DESCRIPTION
This pull request includes changes to the `mergekit` package to add support for merging buffer values. The most important changes include updating the package version, adding buffer handling in the `mergekit` function, and adding tests to ensure buffer values are merged correctly.

Buffer handling:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R299-R302): Added a check to handle buffer values by converting them to strings during the merge process.

Testing:

* [`test/index.test.ts`](diffhunk://#diff-ec61822d929089017a892b4b047229377c9241f16b43252ab851ae39131cdf40R1045-R1076): Added a new test suite `Mergekit Buffers` with tests to verify that buffer values are merged correctly, handled within objects, and merged with other types.